### PR TITLE
update example to read_raw instead of Raw

### DIFF
--- a/examples/plot_from_raw_to_epochs.py
+++ b/examples/plot_from_raw_to_epochs.py
@@ -7,7 +7,7 @@ import numpy as np
 
 fname = '../pyeparse/tests/data/test_raw.edf'
 
-raw = pp.Raw(fname)
+raw = pp.read_raw(fname)
 
 # visualize initial calibration
 raw.plot_calibration(title='5-Point Calibration')


### PR DESCRIPTION
Looks like there was a change from `Raw` class to `read_raw` function at some point, and the example file got missed.