### PR TITLE
Strip whitespace from file name in `read_raw`

### DIFF
--- a/pyeparse/_baseraw.py
+++ b/pyeparse/_baseraw.py
@@ -291,7 +291,7 @@ def read_raw(fname):
         The name of the eye-tracker data file.
         Files currently supported are EDF and HD5
     """
-    _, ext = op.splitext(fname)
+    _, ext = op.splitext(fname.strip())
     if ext == '.edf':
         from .edf._raw import RawEDF
         raw = RawEDF(fname)


### PR DESCRIPTION
Passing a file name like `/path/to/file.edf '  (note the terminal whitespace) causes `read_raw` to throw a cryptic `UnboundLocalError`.

This PR addresses the issue by performing a bit of cleanup on the file name.