### PR TITLE
Fixes: bindings to EDFAPI C library (not urgent)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
 before_install:
   - sudo add-apt-repository "deb http://download.sr-support.com/software SRResearch main"
-  - wget -O - "http://download.sr-support.com/software/dists/SRResearch/SRResearch_key" | sudo apt-key add -
+  - wget -O - "http://download.sr-support.com/software/SRResearch_key" | sudo apt-key add -
   - sudo apt-get update
 
 install:

--- a/pyeparse/edf/_edf2py.py
+++ b/pyeparse/edf/_edf2py.py
@@ -4,7 +4,8 @@
 import struct
 import sys
 from ctypes import (c_int, Structure, c_char, c_char_p, c_ubyte,
-                    c_short, c_ushort, c_uint, c_float, POINTER, CDLL, util)
+                    c_short, c_ushort, c_uint, c_float, POINTER, CDLL, util,
+                    Union)
 
 # find and load the library
 if sys.platform.startswith('win') and (8 * struct.calcsize("P") == 64):
@@ -108,23 +109,10 @@ edf_get_preamble_text = edfapi.edf_get_preamble_text
 edf_get_preamble_text.argtypes = [POINTER(EDFFILE), c_char_p, c_int]
 edf_get_preamble_text.restype = c_int
 
-edf_get_recording_data = edfapi.edf_get_recording_data
-edf_get_recording_data.argtypes = [POINTER(EDFFILE)]
-edf_get_recording_data.restype = POINTER(RECORDINGS)
-
-edf_get_sample_data = edfapi.edf_get_sample_data
-edf_get_sample_data.argtypes = [POINTER(EDFFILE)]
-edf_get_sample_data.restype = POINTER(FSAMPLE)
-
-edf_get_event_data = edfapi.edf_get_event_data
-edf_get_event_data.argtypes = [POINTER(EDFFILE)]
-edf_get_event_data.restype = POINTER(FEVENT)
-
-"""
-from ctypes import Union
 
 class IMESSAGE(Structure):
     pass
+
 
 IMESSAGE.__slots__ = ['time', 'type', 'length', 'text']
 IMESSAGE._fields_ = [('time', c_uint), ('type', c_short), ('length', c_ushort),
@@ -134,12 +122,14 @@ IMESSAGE._fields_ = [('time', c_uint), ('type', c_short), ('length', c_ushort),
 class IOEVENT(Structure):
     pass
 
+
 IOEVENT.__slots__ = ['time', 'type', 'data']
 IOEVENT._fields_ = [('time', c_uint), ('type', c_short), ('data', c_ushort)]
 
 
 class ALLF_DATA(Union):
     pass
+
 
 ALLF_DATA.__slots__ = ['fe', 'im', 'io', 'fs', 'rec']
 ALLF_DATA._fields_ = [('fe', FEVENT), ('im', IMESSAGE), ('io', IOEVENT),
@@ -149,6 +139,7 @@ edf_get_float_data = edfapi.edf_get_float_data
 edf_get_float_data.argtypes = [POINTER(EDFFILE)]
 edf_get_float_data.restype = POINTER(ALLF_DATA)
 
+"""
 edf_get_sample_close_to_time = edfapi.edf_get_sample_close_to_time
 edf_get_sample_close_to_time.argtypes = [POINTER(EDFFILE), c_uint]
 edf_get_sample_close_to_time.restype = POINTER(ALLF_DATA)

--- a/pyeparse/edf/_raw.py
+++ b/pyeparse/edf/_raw.py
@@ -11,14 +11,12 @@ import warnings
 try:
     from ._edf2py import (edf_open_file, edf_close_file, edf_get_next_data,
                           edf_get_preamble_text, edf_get_preamble_text_length,
-                          edf_get_recording_data, edf_get_sample_data,
-                          edf_get_event_data)
+                          edf_get_float_data)
     has_edfapi = True
     why_not = None
 except OSError as exp:
     (edf_open_file, edf_close_file, edf_get_next_data, edf_get_preamble_text,
-     edf_get_preamble_text_length, edf_get_recording_data, edf_get_sample_data,
-     edf_get_event_data) = [None] * 8
+     edf_get_preamble_text_length, edf_get_float_data) = [None] * 8
     has_edfapi = False
     why_not = str(exp)
 
@@ -301,7 +299,7 @@ for key, val in _pp2el.items():
 def _handle_recording_info(edf, res):
     """RECORDING_INFO"""
     info = res['info']
-    e = edf_get_recording_data(edf).contents
+    e = edf_get_float_data(edf).contents.rec
     if e.state == 0:  # recording stopped
         return
     if 'sfreq' in info:
@@ -328,7 +326,7 @@ def _handle_recording_info(edf, res):
 
 def _handle_sample(edf, res):
     """SAMPLE_TYPE"""
-    e = edf_get_sample_data(edf).contents
+    e = edf_get_float_data(edf).contents.fs
     off = res['offsets']['sample']
     res['samples'][:, off] = _to_list(e, res['edf_sample_fields'],
                                       res['eye_idx'])
@@ -337,7 +335,7 @@ def _handle_sample(edf, res):
 
 def _handle_message(edf, res):
     """MESSAGEEVENT"""
-    e = edf_get_event_data(edf).contents
+    e = edf_get_float_data(edf).contents.fe
     msg = ct.string_at(ct.byref(e.message[0]), e.message.contents.len + 1)[2:]
     msg = msg.decode('UTF-8')
     msg = ''.join([i if ord(i) < 128 else '' for i in msg])
@@ -371,7 +369,7 @@ def _handle_end(edf, res, name):
         our_names = [_el2pp[field] for field in f]
         dtype = [(ff, np.float64) for ff in our_names]
         res['discrete'][name] = np.empty(res['n_samps'][name], dtype=dtype)
-    e = edf_get_event_data(edf).contents
+    e = edf_get_float_data(edf).contents.fe
     vals = _to_list(e, res['edf_fields'][name], res['eye_idx'])
     off = res['offsets'][name]
     for ff, vv in zip(res['discrete'][name].dtype.names, vals):

--- a/pyeparse/utils.py
+++ b/pyeparse/utils.py
@@ -124,8 +124,17 @@ def _has_edfapi():
     return has_edfapi
 
 
-_requires_h5py = np.testing.dec.skipif(not _has_h5py(),
-                                       'Requires h5py')
+def _requires_h5py(func):
+    """Skip testing if h5py is not installed."""
+    import pytest
+
+    return pytest.mark.skipif(not _has_h5py(),
+                              reason='Requires h5py')(func)
 
 
-_requires_edfapi = np.testing.dec.skipif(not _has_edfapi(), 'Requires edfapi')
+def _requires_edfapi(func):
+    """Skip testing if edfapi is not installed."""
+    import pytest
+
+    return pytest.mark.skipif(not _has_edfapi(),
+                              reason='Requires edfapi')(func)


### PR DESCRIPTION
Sorry for making a commotion in this peaceful neck of the woods. 

Long story short, I found the EDF reading code in pyeparse to be super helpful, and I'm going to try to maintain it in this smaller repo: [eyelinkio](https://github.com/scott-huberty/eyelinkio).


But due to a Numpy deprecation and an API change from SR Research, I had to do a little refactoring to get the EDF reading functions to work. I opened this PR so that pyeparse can have them too (_if you want it_). If you do then I'll try to fix the other test failures (I'm sure there will be one or two 🙂 ). If not then feel free to disregard this.


The individual commit messages contain more details about each fix.